### PR TITLE
Add missing "status" field on capture responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ orderId
   <amount>10.20</amount>
   <message>F                 REDE                 @    CONFIRMACAO DE PRE-AUTORIZACAO    @COMPR:257575054    VALOR:        10.20@ESTAB:040187624 DINDA COM BR          @24.07.14-16:27:33 TERM:RO128278/528374@AUTORIZACAO EMISSOR: 642980           @CODIGO PRE-AUTORIZACAO: 52978         @CARTAO: xxxxxxxxxxxx1111              @     RECONHECO E PAGAREI A DIVIDA     @          AQUI REPRESENTADA           @@@     ____________________________     @@</message>
   <returnCode>0</returnCode>
+  <status>0</status>
   <transactionId>257575054</transactionId>
 </PagadorReturn>
 ```
@@ -116,6 +117,7 @@ Example of the failure response:
   <amount>10.20</amount>
   <message>Capture denied</message>
   <returnCode>2</returnCode>
+  <status>2</status>
   <transactionId>257575054</transactionId>
 </PagadorReturn>
 ```
@@ -170,6 +172,7 @@ Example of the failure response:
   <amount>12,34</amount>
   <message>Capture partial denied</message>
   <returnCode>2</returnCode>
+  <status>2</status>
   <transactionId>257575054</transactionId>
 </PagadorReturn>
 ```

--- a/lib/fake_braspag/views/capture_failure.builder
+++ b/lib/fake_braspag/views/capture_failure.builder
@@ -5,5 +5,6 @@ xml.PagadorReturn 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
   xml.amount order.amount
   xml.message 'Capture denied'
   xml.returnCode 2
+  xml.status 2
   xml.transactionId 257575054
 end

--- a/lib/fake_braspag/views/capture_partial_failure.builder
+++ b/lib/fake_braspag/views/capture_partial_failure.builder
@@ -5,5 +5,6 @@ xml.PagadorReturn 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
   xml.amount order.amount
   xml.message 'Capture partial denied'
   xml.returnCode 2
+  xml.status 2
   xml.transactionId 257575054
 end

--- a/lib/fake_braspag/views/capture_success.builder
+++ b/lib/fake_braspag/views/capture_success.builder
@@ -15,5 +15,6 @@ xml.PagadorReturn 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
     "          AQUI REPRESENTADA           @@@" +
     "     ____________________________     @@"
   xml.returnCode 0
+  xml.status 0
   xml.transactionId 257575054
 end

--- a/spec/fake_braspag_spec.rb
+++ b/spec/fake_braspag_spec.rb
@@ -99,6 +99,7 @@ describe FakeBraspag do
           <amount>#{order.amount}</amount>
           <message>F                 REDE                 @    CONFIRMACAO DE PRE-AUTORIZACAO    @COMPR:257575054    VALOR:        #{order.amount}@ESTAB:040187624 DINDA COM BR          @24.07.14-16:27:33 TERM:RO128278/528374@AUTORIZACAO EMISSOR: 642980           @CODIGO PRE-AUTORIZACAO: 52978         @CARTAO: xxxxxxxxxxxx1111              @     RECONHECO E PAGAREI A DIVIDA     @          AQUI REPRESENTADA           @@@     ____________________________     @@</message>
           <returnCode>0</returnCode>
+          <status>0</status>
           <transactionId>257575054</transactionId>
         </PagadorReturn>
         XML
@@ -151,6 +152,7 @@ describe FakeBraspag do
           <amount>#{order.amount}</amount>
           <message>Capture denied</message>
           <returnCode>2</returnCode>
+          <status>2</status>
           <transactionId>257575054</transactionId>
         </PagadorReturn>
         XML
@@ -266,6 +268,7 @@ describe FakeBraspag do
           <amount>#{order.amount}</amount>
           <message>Capture partial denied</message>
           <returnCode>2</returnCode>
+          <status>2</status>
           <transactionId>257575054</transactionId>
         </PagadorReturn>
         XML


### PR DESCRIPTION
The [application code on dinda-core](https://github.com/Dinda-com-br/dinda-all/blob/master/dinda-core/lib/dinda-core/payments/gateway_support/capture_response.rb#L4-L10) depends on status code field. So, for instance, without it, successful captured operations will be considered as failed ones. This PR fix that.

cc @pmatiello 
