### PR TITLE
Create a captured order when uses just click shop

### DIFF
--- a/lib/fake_braspag/credit_cards.rb
+++ b/lib/fake_braspag/credit_cards.rb
@@ -59,8 +59,12 @@ module FakeBraspag
 
     def just_click_shop(authorization_params)
       card = FakeBraspag::CreditCard.new(authorization_params)
+      order = Order.new('orderId' => authorization_params['OrderId'], 'amount' => authorization_params['Amount'])
 
       if ResponseToggler.enabled?('just_click_shop') && card.just_click_shop
+        order.authorize!
+        order.capture!
+
         builder :just_click_shop_success, locals: { card: card }
       else
         builder :just_click_shop_failure, locals: { card: card }

--- a/spec/credit_cards_spec.rb
+++ b/spec/credit_cards_spec.rb
@@ -166,7 +166,7 @@ describe FakeBraspag::CreditCards do
         allow(ResponseToggler).to receive(:enabled?).with('just_click_shop').and_return(true)
       end
 
-      it 'renders a successful response' do
+      it 'renders a successful response and saves a captured order' do
         request_id = 'bf4616ea-448a-4a15-9590-ce1163f3ad50'
         just_click_key = '370a5342-c97a-4e55-8157-95c23fe18d03'
         amount = 1234
@@ -215,6 +215,9 @@ describe FakeBraspag::CreditCards do
             </soap:Body>
           </soap:Envelope>
         XML
+
+        order = Order.find('123456')
+        expect(order).to be_captured
       end
 
       it 'renders a failure response when no RequestId is provided' do


### PR DESCRIPTION
This PR introduces a creation of captured order when used just click shop method to keep compatibility between behavior from just click shop flow.

After that, we check order data using get status order api.