### PR TITLE
Mocking redis calls

### DIFF
--- a/spec/credit_cards_spec.rb
+++ b/spec/credit_cards_spec.rb
@@ -104,7 +104,7 @@ describe FakeBraspag::CreditCards do
     end
 
     context 'when the response is disabled' do
-      before { ResponseToggler.disable('save_credit_card') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('save_credit_card').and_return(false) }
 
       it 'renders a failure response' do
         request_id = 'bf4616ea-448a-4a15-9590-ce1163f3ad50'
@@ -265,7 +265,7 @@ describe FakeBraspag::CreditCards do
     end
 
     context 'when the response is disabled' do
-      before { ResponseToggler.disable('just_click_shop') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('just_click_shop').and_return(false) }
 
       it 'renders a failure response' do
         request_id = 'bf4616ea-448a-4a15-9590-ce1163f3ad50'
@@ -366,7 +366,7 @@ describe FakeBraspag::CreditCards do
     end
 
     context 'when the response is disabled' do
-      before { ResponseToggler.disable('get_credit_card') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_credit_card').and_return(false) }
 
       it 'renders a failure response' do
         post 'FakeCreditCard/CartaoProtegido.asmx', <<-XML.strip_heredoc

--- a/spec/credit_cards_spec.rb
+++ b/spec/credit_cards_spec.rb
@@ -15,7 +15,7 @@ describe FakeBraspag::CreditCards do
 
   describe 'SaveCreditCard' do
     context 'when the response is enabled' do
-      before { ResponseToggler.enable('save_credit_card') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('save_credit_card').and_return(true) }
 
       it 'renders a successful response with a valid just click key and a correlation id' do
         request_id = 'bf4616ea-448a-4a15-9590-ce1163f3ad50'
@@ -158,7 +158,7 @@ describe FakeBraspag::CreditCards do
 
   describe 'JustClickShop' do
     context 'when the response is enabled' do
-      before { ResponseToggler.enable('just_click_shop') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('just_click_shop').and_return(true) }
 
       it 'renders a successful response and saves a captured order' do
         request_id = 'bf4616ea-448a-4a15-9590-ce1163f3ad50'
@@ -325,7 +325,7 @@ describe FakeBraspag::CreditCards do
 
   describe 'GetCreditCard' do
     context 'when the response is enabled' do
-      before { ResponseToggler.enable('get_credit_card') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_credit_card').and_return(true) }
 
       it 'returns a valid credit card result' do
         post 'FakeCreditCard/CartaoProtegido.asmx', <<-XML.strip_heredoc

--- a/spec/fake_braspag_spec.rb
+++ b/spec/fake_braspag_spec.rb
@@ -82,9 +82,7 @@ describe FakeBraspag do
 
   describe 'capture' do
     context 'when the response is enabled' do
-      before do
-        ResponseToggler.enable('capture')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(true) }
 
       it 'renders a successful response with the order amount, return code and transaction id' do
         order = Order.create(order_params)
@@ -135,9 +133,7 @@ describe FakeBraspag do
     end
 
     context 'when the response is disabled' do
-      before do
-        ResponseToggler.disable('capture')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(false) }
 
       it 'renders a failure response with the order amount, return code and transaction id' do
         order = Order.create(order_params)
@@ -190,9 +186,7 @@ describe FakeBraspag do
 
   describe 'partial capture' do
     context 'when the response is enabled' do
-      before do
-        ResponseToggler.enable('capture_partial')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(true) }
 
       it 'renders a successful response with the captured amount and the transaction status' do
         Order.create(order_params)
@@ -249,9 +243,7 @@ describe FakeBraspag do
     end
 
     context 'when the response is disabled' do
-      before do
-        ResponseToggler.disable('capture_partial')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(false) }
 
       it 'renders a failure response with the order amount, return code and transaction id' do
         order = Order.create(order_params)
@@ -311,17 +303,15 @@ describe FakeBraspag do
 
   describe 'disable capture' do
     it 'disables the capture response' do
-      ResponseToggler.enable('capture')
+      allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(true)
 
       get '/capture/disable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('capture')).to be_falsy
     end
 
     it 'returns not modified if the capture is already disabled' do
-      ResponseToggler.disable('capture')
+      allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(false)
 
       get '/capture/disable'
 
@@ -331,17 +321,15 @@ describe FakeBraspag do
 
   describe 'enable capture' do
     it 'enables the capture response' do
-      ResponseToggler.disable('capture')
+      allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(false)
 
       get '/capture/enable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('capture')).to be_truthy
     end
 
     it 'returns not modified if the capture is already enabled' do
-      ResponseToggler.enable('capture')
+      allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(true)
 
       get '/capture/enable'
 
@@ -351,17 +339,15 @@ describe FakeBraspag do
 
   describe 'disable partial capture' do
     it 'disables the partial capture response' do
-      ResponseToggler.enable('capture_partial')
+      allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(true)
 
       get '/capture_partial/disable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('capture_partial')).to be_falsy
     end
 
     it 'returns not modified if the partial capture is already disabled' do
-      ResponseToggler.disable('capture_partial')
+      allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(false)
 
       get '/capture_partial/disable'
 
@@ -371,17 +357,15 @@ describe FakeBraspag do
 
   describe 'enable partial capture' do
     it 'enables the partial capture response' do
-      ResponseToggler.disable('capture_partial')
+      allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(false)
 
       get '/capture_partial/enable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('capture_partial')).to be_truthy
     end
 
     it 'returns not modified if the partial capture is already enabled' do
-      ResponseToggler.enable('capture_partial')
+      allow(ResponseToggler).to receive(:enabled?).with('capture_partial').and_return(true)
 
       get '/capture_partial/enable'
 

--- a/spec/orders_spec.rb
+++ b/spec/orders_spec.rb
@@ -27,9 +27,7 @@ describe FakeBraspag::Orders do
 
   describe 'get status order' do
     context 'when the response is enabled' do
-      before do
-        ResponseToggler.enable('get_status_order')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_status_order').and_return(true) }
 
       it 'renders a successful response with the order amount and the transaction status' do
         order = Order.create(order_params)
@@ -68,9 +66,7 @@ describe FakeBraspag::Orders do
     end
 
     context 'when the response is disabled' do
-      before do
-        ResponseToggler.disable('get_status_order')
-      end
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_status_order').and_return(false) }
 
       it 'renders a failure response with the order amount, return code and transaction id' do
         order = Order.create(order_params)
@@ -111,17 +107,15 @@ describe FakeBraspag::Orders do
 
   describe 'disable get status order' do
     it 'disables the get status response' do
-      ResponseToggler.enable('get_status_order')
+      allow(ResponseToggler).to receive(:enabled?).with('get_status_order').and_return(true)
 
       get '/get_status_order/disable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('get_status_order')).to be_falsy
     end
 
     it 'returns not modified if the get status order is already disabled' do
-      ResponseToggler.disable('get_status_order')
+      allow(ResponseToggler).to receive(:enabled?).with('get_status_order').and_return(false)
 
       get '/get_status_order/disable'
 
@@ -131,13 +125,11 @@ describe FakeBraspag::Orders do
 
   describe 'enable get status order' do
     it 'enables the get status order response' do
-      ResponseToggler.disable('get_status_order')
+      allow(ResponseToggler).to receive(:enabled?).with('get_status_order').and_return(false)
 
       get '/get_status_order/enable'
 
       expect(last_response).to be_ok
-
-      expect(ResponseToggler.enabled?('get_status_order')).to be_truthy
     end
 
     it 'returns not modified if the get status order is already enabled' do

--- a/spec/sales_spec.rb
+++ b/spec/sales_spec.rb
@@ -153,7 +153,7 @@ describe FakeBraspag::Sales do
 
   describe 'capture a sale' do
     context 'successful response' do
-      before { ResponseToggler.enable('capture') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(true) }
 
       it 'responds with a success response' do
         put "/v2/sales/2014111703/capture"
@@ -167,7 +167,7 @@ describe FakeBraspag::Sales do
     end
 
     context 'failure response' do
-      before { ResponseToggler.disable('capture') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('capture').and_return(false) }
 
       it 'responds with an error response' do
         put "/v2/sales/2014111703/capture"
@@ -182,7 +182,7 @@ describe FakeBraspag::Sales do
 
   describe 'sale cancelation' do
     context 'success' do
-      before { ResponseToggler.enable('void') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('void').and_return(true) }
 
       it 'responds with a success response' do
         put "/v2/sales/2014111703/void"
@@ -196,7 +196,7 @@ describe FakeBraspag::Sales do
     end
 
     context 'failure' do
-      before { ResponseToggler.disable('void') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('void').and_return(false) }
 
       it 'responds with an error response' do
         put "/v2/sales/2014111703/void"
@@ -211,7 +211,7 @@ describe FakeBraspag::Sales do
 
   describe 'search sale' do
     context 'success' do
-      before { ResponseToggler.enable('get_sale') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_sale').and_return(true) }
 
       it 'responds with a success response' do
         get "/v2/sales/2014111703"
@@ -256,7 +256,7 @@ describe FakeBraspag::Sales do
     end
 
     context 'failure' do
-      before { ResponseToggler.disable('get_sale') }
+      before { allow(ResponseToggler).to receive(:enabled?).with('get_sale').and_return(false) }
 
       it 'responds with an error response' do
         get "/v2/sales/2014111703"


### PR DESCRIPTION
@britto warned [here](https://github.com/Baby-com-br/fake-braspag/pull/19#discussion-diff-34040543R18),  calling `ResponseToggler.enable` or `ResponseToggler.disable` on specs, it will actually write into redis. This PR was created to prevent leak between specs. We are now mocking that.
