### PR TITLE
Allow boleto orders to conciliate diferent values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fake_braspag (1.3.0)
+    fake_braspag (1.4.0)
       activesupport (~> 4.1)
       builder (~> 3.2)
       redis (~> 3.1)

--- a/lib/fake_braspag/sales.rb
+++ b/lib/fake_braspag/sales.rb
@@ -43,7 +43,7 @@ module FakeBraspag
     put '/:PaymentId/conciliate' do
       order = Order.find(params[:PaymentId])
       if order.present? && order.boleto? && ResponseToggler.enabled?('conciliate')
-        order.pay_boleto!
+        order.pay_boleto!(params[:amount])
         @sale = SalePresenter.new(order)
         jbuilder :sale_conciliate
       else

--- a/lib/fake_braspag/views/get_boleto_sale.jbuilder
+++ b/lib/fake_braspag/views/get_boleto_sale.jbuilder
@@ -15,6 +15,7 @@ json.Payment do |payment|
   payment.PaymentId @sale.id
   payment.Type "Boleto"
   payment.Amount @sale.amount
+  payment.CapturedAmount @sale.captured_amount
   payment.ReceivedDate "2015-04-25 08:34:04"
   payment.Currency "BRL"
   payment.Country "BRA"

--- a/lib/fake_braspag/views/sale_conciliate.jbuilder
+++ b/lib/fake_braspag/views/sale_conciliate.jbuilder
@@ -15,6 +15,7 @@ json.Payment do |payment|
   payment.PaymentId @sale.id
   payment.Type "Boleto"
   payment.Amount @sale.amount
+  payment.CapturedAmount @sale.captured_amount
   payment.ReceivedDate "2015-04-25 08:34:04"
   payment.Currency "BRL"
   payment.Country "BRA"

--- a/lib/models/order.rb
+++ b/lib/models/order.rb
@@ -154,11 +154,14 @@ class Order
     save
   end
 
-  # Public: Simulates an order boleto payment.
+  # Public: Simulates an order boleto payment. When an amount is provided. The captured_amount is the provided amount
   #
   # Examples
   #
   #   order.pay_boleto!
+  #   # => true
+  #
+  #   order.pay_boleto!('15,00')
   #   # => true
   #
   # Returns true if the payment was successful and false otherwise.

--- a/lib/models/order.rb
+++ b/lib/models/order.rb
@@ -162,8 +162,15 @@ class Order
   #   # => true
   #
   # Returns true if the payment was successful and false otherwise.
-  def pay_boleto!
-    @attributes['boleto_status'] = 'boleto_paid'
+  def pay_boleto!(amount = nil)
+    if amount
+      normalized_amount = normalize_amount(amount)
+      @attributes['boleto_status'] = 'boleto_paid' if normalized_amount.to_i >= self.amount.to_i
+      @attributes['capturedAmount'] = normalized_amount
+    else
+      @attributes['boleto_status'] = 'boleto_paid'
+      @attributes['capturedAmount'] = self.amount
+    end
 
     save
   end

--- a/lib/presenters/sale_presenter.rb
+++ b/lib/presenters/sale_presenter.rb
@@ -12,7 +12,7 @@ class SalePresenter
   end
 
   def captured_amount
-    (@order.captured_amount.to_f * 100).to_i
+    @order.respond_to?(:captured_amount) ? (@order.captured_amount.to_f * 100).to_i : 0
   end
 
   def save_card

--- a/lib/presenters/sale_presenter.rb
+++ b/lib/presenters/sale_presenter.rb
@@ -11,6 +11,10 @@ class SalePresenter
     (@order.amount.to_f * 100).to_i
   end
 
+  def captured_amount
+    (@order.captured_amount.to_f * 100).to_i
+  end
+
   def save_card
     @order.saveCard
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -233,7 +233,7 @@ describe Order do
       end
     end
 
-    context 'when no captured amount is provided' do
+    context 'when provided captured amount is more than amount' do
       it 'marks the order as boleto_paid' do
         order = Order.new(order_params.merge('paymentMethod' => 'Boleto', 'boleto_status' => 'boleto_issued'))
         expect(order).not_to be_boleto_paid

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -209,13 +209,40 @@ describe Order do
   end
 
   describe '#pay_boleto!' do
-    it 'marks the order as boleto_paid' do
-      order = Order.new(order_params.merge('paymentMethod' => 'Boleto', 'boleto_status' => 'boleto_issued'))
-      expect(order).not_to be_boleto_paid
+    context 'when no captured amount is provided' do
+      it 'marks the order as boleto_paid' do
+        order = Order.new(order_params.merge('paymentMethod' => 'Boleto', 'boleto_status' => 'boleto_issued'))
+        expect(order).not_to be_boleto_paid
 
-      order.pay_boleto!
+        order.pay_boleto!
 
-      expect(order).to be_boleto_paid
+        expect(order).to be_boleto_paid
+        expect(order.captured_amount).to eq(order.amount)
+      end
+    end
+
+    context 'when provided captured amount is less than amount' do
+      it 'does not mark the order as boleto_paid' do
+        order = Order.new(order_params.merge('paymentMethod' => 'Boleto', 'boleto_status' => 'boleto_issued'))
+        expect(order).not_to be_boleto_paid
+
+        order.pay_boleto!('15,00')
+
+        expect(order).not_to be_boleto_paid
+        expect(order.captured_amount).to be < order.amount
+      end
+    end
+
+    context 'when no captured amount is provided' do
+      it 'marks the order as boleto_paid' do
+        order = Order.new(order_params.merge('paymentMethod' => 'Boleto', 'boleto_status' => 'boleto_issued'))
+        expect(order).not_to be_boleto_paid
+
+        order.pay_boleto!('20,00')
+
+        expect(order).to be_boleto_paid
+        expect(order.captured_amount).to be > order.amount
+      end
     end
   end
 

--- a/spec/presenters/sale_presenter_spec.rb
+++ b/spec/presenters/sale_presenter_spec.rb
@@ -23,6 +23,21 @@ describe SalePresenter do
     end
   end
 
+  describe '#captured_amount' do
+    context 'when order is boleto paid' do
+      it 'returns captured amount in braspag format' do
+        order.pay_boleto!
+        expect(sale.captured_amount).to eq(15700)
+      end
+    end
+
+    context 'when order has not been asked to pay boleto' do
+      it 'returns captured amount in braspag format' do
+        expect(sale.captured_amount).to be_zero
+      end
+    end
+  end
+
   describe '#reason_code' do
     it 'returns 0 when order is authorized' do
       order.authorize!

--- a/spec/sales_spec.rb
+++ b/spec/sales_spec.rb
@@ -384,41 +384,124 @@ describe FakeBraspag::Sales do
   describe 'conciliate' do
     context 'with boleto' do
       context 'success' do
-        it 'responds with a success response' do
-          post '/v2/sales/', boleto_order_params.to_json, { 'Content-Type' => 'application/json' }
-          put "/v2/sales/2014111706/conciliate"
+        context 'with exact boleto amount' do
+          it 'responds with a success response' do
+            post '/v2/sales/', boleto_order_params.to_json, { 'Content-Type' => 'application/json' }
+            put "/v2/sales/2014111706/conciliate"
 
-          expect(last_response).to be_ok
-          expect(JSON.parse(last_response.body)).to eq({
-            "MerchantOrderId" => "2014111706",
-            "Customer" =>
-            {
-              "Name" => "Comprador Teste"
-            },
-            "Payment" =>
-            {
-              "Instructions" => "Aceitar somente ate a data de vencimento, apos essa data juros de 1 por cento dia.",
-              "ExpirationDate" => Date.tomorrow.strftime('%Y-%m-%d'),
-              "Url" => "https =>//apisandbox.braspag.com.br/post/pagador/reenvia.asp/a5f3181d-c2e2-4df9-a5b4-d8f6edf6bd51",
-              "BoletoNumber" => "123-2",
-              "BarCodeNumber" => "00096629900000157000494250000000012300656560",
-              "DigitableLine" => "00090.49420 50000.000013 23006.565602 6 62990000015700",
-              "Assignor" => "Empresa Teste",
-              "Address" => "Rua Teste",
-              "Identification" => "11884926754",
-              "PaymentId" => "2014111706",
-              "Type" => "Boleto",
-              "Amount" => 15700,
-              "ReceivedDate" => "2015-04-25 08:34:04",
-              "Currency" => "BRL",
-              "Country" => "BRA",
-              "Provider" => "Simulado",
-              "ReasonCode" => 0,
-              "ReasonMessage" => "Successful",
-              "Status" => 2,
-              "Links" => []
-            }
-          })
+            expect(last_response).to be_ok
+            expect(JSON.parse(last_response.body)).to eq({
+              "MerchantOrderId" => "2014111706",
+              "Customer" =>
+              {
+                "Name" => "Comprador Teste"
+              },
+              "Payment" =>
+              {
+                "Instructions" => "Aceitar somente ate a data de vencimento, apos essa data juros de 1 por cento dia.",
+                "ExpirationDate" => Date.tomorrow.strftime('%Y-%m-%d'),
+                "Url" => "https =>//apisandbox.braspag.com.br/post/pagador/reenvia.asp/a5f3181d-c2e2-4df9-a5b4-d8f6edf6bd51",
+                "BoletoNumber" => "123-2",
+                "BarCodeNumber" => "00096629900000157000494250000000012300656560",
+                "DigitableLine" => "00090.49420 50000.000013 23006.565602 6 62990000015700",
+                "Assignor" => "Empresa Teste",
+                "Address" => "Rua Teste",
+                "Identification" => "11884926754",
+                "PaymentId" => "2014111706",
+                "Type" => "Boleto",
+                "Amount" => 15700,
+                "CapturedAmount" => 15700,
+                "ReceivedDate" => "2015-04-25 08:34:04",
+                "Currency" => "BRL",
+                "Country" => "BRA",
+                "Provider" => "Simulado",
+                "ReasonCode" => 0,
+                "ReasonMessage" => "Successful",
+                "Status" => 2,
+                "Links" => []
+              }
+            })
+          end
+        end
+
+        context 'with less than boleto amount' do
+          it 'responds with a success response, status 1 and the captured amount' do
+            post '/v2/sales/', boleto_order_params.to_json, { 'Content-Type' => 'application/json' }
+            put "/v2/sales/2014111706/conciliate", {amount: '50,00'}
+
+            expect(last_response).to be_ok
+            expect(JSON.parse(last_response.body)).to eq({
+              "MerchantOrderId" => "2014111706",
+              "Customer" =>
+              {
+                "Name" => "Comprador Teste"
+              },
+              "Payment" =>
+              {
+                "Instructions" => "Aceitar somente ate a data de vencimento, apos essa data juros de 1 por cento dia.",
+                "ExpirationDate" => Date.tomorrow.strftime('%Y-%m-%d'),
+                "Url" => "https =>//apisandbox.braspag.com.br/post/pagador/reenvia.asp/a5f3181d-c2e2-4df9-a5b4-d8f6edf6bd51",
+                "BoletoNumber" => "123-2",
+                "BarCodeNumber" => "00096629900000157000494250000000012300656560",
+                "DigitableLine" => "00090.49420 50000.000013 23006.565602 6 62990000015700",
+                "Assignor" => "Empresa Teste",
+                "Address" => "Rua Teste",
+                "Identification" => "11884926754",
+                "PaymentId" => "2014111706",
+                "Type" => "Boleto",
+                "Amount" => 15700,
+                "CapturedAmount" => 5000,
+                "ReceivedDate" => "2015-04-25 08:34:04",
+                "Currency" => "BRL",
+                "Country" => "BRA",
+                "Provider" => "Simulado",
+                "ReasonCode" => 0,
+                "ReasonMessage" => "Successful",
+                "Status" => 1,
+                "Links" => []
+              }
+            })
+          end
+        end
+
+        context 'with more than boleto amount' do
+          it 'responds with a success response, status 2 and the captured amount' do
+            post '/v2/sales/', boleto_order_params.to_json, { 'Content-Type' => 'application/json' }
+            put "/v2/sales/2014111706/conciliate", {amount: '200,00'}
+
+            expect(last_response).to be_ok
+            expect(JSON.parse(last_response.body)).to eq({
+              "MerchantOrderId" => "2014111706",
+              "Customer" =>
+              {
+                "Name" => "Comprador Teste"
+              },
+              "Payment" =>
+              {
+                "Instructions" => "Aceitar somente ate a data de vencimento, apos essa data juros de 1 por cento dia.",
+                "ExpirationDate" => Date.tomorrow.strftime('%Y-%m-%d'),
+                "Url" => "https =>//apisandbox.braspag.com.br/post/pagador/reenvia.asp/a5f3181d-c2e2-4df9-a5b4-d8f6edf6bd51",
+                "BoletoNumber" => "123-2",
+                "BarCodeNumber" => "00096629900000157000494250000000012300656560",
+                "DigitableLine" => "00090.49420 50000.000013 23006.565602 6 62990000015700",
+                "Assignor" => "Empresa Teste",
+                "Address" => "Rua Teste",
+                "Identification" => "11884926754",
+                "PaymentId" => "2014111706",
+                "Type" => "Boleto",
+                "Amount" => 15700,
+                "CapturedAmount" => 20000,
+                "ReceivedDate" => "2015-04-25 08:34:04",
+                "Currency" => "BRL",
+                "Country" => "BRA",
+                "Provider" => "Simulado",
+                "ReasonCode" => 0,
+                "ReasonMessage" => "Successful",
+                "Status" => 2,
+                "Links" => []
+              }
+            })
+          end
         end
       end
 

--- a/spec/sales_spec.rb
+++ b/spec/sales_spec.rb
@@ -353,6 +353,7 @@ describe FakeBraspag::Sales do
               "PaymentId" => "2014111706",
               "Type" => "Boleto",
               "Amount" => 15700,
+              "CapturedAmount"=>0,
               "ReceivedDate" => "2015-04-25 08:34:04",
               "Currency" => "BRL",
               "Country" => "BRA",


### PR DESCRIPTION
This PR introduces boleto conciliation with a diferent value of the boleto.
The behavior is:

- When the paid value is lass than the boleto value, The order is not set as paid and the captured amount is the paid value;
- When the paid value is equal to the boleto value, the captured amount is the boleto value and the order is set as boleto paid;
- When the paid value is greater than the boleto value, the captured amount is the paid value and the order is set as boleto paid.